### PR TITLE
Add nokogiri ver attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following dependencies are installed via rsdns::default.
 
 ### Gems
 
+* [nokogiri](http://www.nokogiri.org/)
 * [fog](http://fog.io/) 
 * [rubydns](http://rubyforge.org/projects/dnsruby/)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@
 default['rsdns']['rackspace_username'] = 'your_rackspace_username'
 default['rsdns']['rackspace_api_key'] = 'your_rackspace_api_key'
 default['rsdns']['rackspace_auth_region'] = 'us'
+default['rsdns']['nokogiri_version'] = '1.6.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'daniel.givens@rackspace.com'
 license          'Apache 2.0'
 description      'Manages DNS records and zones in Rackspace Cloud DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.1.0'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,9 @@ when "redhat", "centos", "fedora", "amazon", "scientific"
   package( "libxml2-devel" ).run_action( :install )
 end
 
+chef_gem "nokogiri" do
+  version node['rsdns']['nokogiri_version']
+end
 chef_gem "fog"
 chef_gem "dnsruby"
 


### PR DESCRIPTION
Chef 11 ships Ruby 1.9.1.
Nokogiri >=1.6.2 requires Ruby >=1.9.2.
NOKOGIRIIIIIII!
This allows us to satisfy the dep for fog.

Tested on Ubuntus.
